### PR TITLE
Added the ability to run image optimizations in a background thread.

### DIFF
--- a/src/MetadataImageOptimizer/MetadataImageOptimizer.cs
+++ b/src/MetadataImageOptimizer/MetadataImageOptimizer.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using MetadataImageOptimizer.Settings;
 using MetadataImageOptimizer.Views;
 using Playnite.SDK;
+using Playnite.SDK.Events;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 
@@ -43,6 +44,25 @@ namespace MetadataImageOptimizer
             };
         }
 
+        public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)
+        {
+            // SOME kind of UI to be shown in the main menu if we're optimizing in the background
+            // Gives users a way to kill it
+            if (settings.Settings.RunInBackground &&
+                _backgroundOptimizeQueue.Count > 0)
+            {
+                yield return new MainMenuItem()
+                {
+                    MenuSection = $"@MetadataImageOptimizer|Optimizing {_backgroundOptimizeQueue.Count} games",
+                    Description = "Cancel",
+                    Action = (a) =>
+                    {
+                        ClearBackgroundOptimizeQueue();
+                    }
+                };
+            }
+        }
+
         public override ISettings GetSettings(bool firstRunSettings)
         {
             return settings;
@@ -51,6 +71,23 @@ namespace MetadataImageOptimizer
         public override UserControl GetSettingsView(bool firstRunSettings)
         {
             return new MetadataImageOptimizerSettingsView();
+        }
+
+        public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
+        {
+            var queueFileExists = File.Exists(_backgroundOptimizeQueueFilePath);
+
+            if (queueFileExists)
+            {
+                if (settings.Settings.RunInBackground)
+                {
+                    LoadBackgroundOptimizeQueueFromFile();
+                }
+                else
+                {
+                    File.Delete(_backgroundOptimizeQueueFilePath);
+                }
+            }
         }
 
         private void OnGameUpdated(object sender, ItemUpdatedEventArgs<Game> e)
@@ -71,19 +108,29 @@ namespace MetadataImageOptimizer
                 return;
             }
 
-            api.Dialogs.ActivateGlobalProgress(
-                globalProgress =>
+            if (optimizerSettings.RunInBackground)
+            {
+                foreach (var change in gamesToUpdate)
                 {
-                    globalProgress.ProgressMaxValue = gamesToUpdate.Count;
-
-                    foreach (var change in gamesToUpdate)
-                    {
-                        OptimizeGame(change, optimizerSettings);
-
-                        globalProgress.CurrentProgressValue += 1;
-                    }
+                    OptimizeGame(change, optimizerSettings);
                 }
-                , new GlobalProgressOptions("Optimizing game images...", false) { IsIndeterminate = gamesToUpdate.Count == 1 });
+            }
+            else
+            {
+                api.Dialogs.ActivateGlobalProgress(
+                    globalProgress =>
+                    {
+                        globalProgress.ProgressMaxValue = gamesToUpdate.Count;
+
+                        foreach (var change in gamesToUpdate)
+                        {
+                            OptimizeGame(change, optimizerSettings);
+
+                            globalProgress.CurrentProgressValue += 1;
+                        }
+                    }
+                    , new GlobalProgressOptions("Optimizing game images...", false) { IsIndeterminate = gamesToUpdate.Count == 1 });
+            }
         }
 
         private void OptimizeGames(List<Game> games, MetadataImageOptimizerSettings optimizerSettings)
@@ -93,24 +140,40 @@ namespace MetadataImageOptimizer
                 return;
             }
 
-            api.Dialogs.ActivateGlobalProgress(
-                globalProgress =>
+
+            if (optimizerSettings.RunInBackground)
+            {
+                foreach (var game in games)
                 {
-                    globalProgress.ProgressMaxValue = games.Count;
-
-                    foreach (var game in games)
-                    {
-                        OptimizeGame(
-                            game
-                            , optimizerSettings
-                            , optimizerSettings.Background.Optimize
-                            , optimizerSettings.Cover.Optimize
-                            , optimizerSettings.Icon.Optimize);
-
-                        globalProgress.CurrentProgressValue += 1;
-                    }
+                    QueueOptimizeGame(
+                        game.Id
+                        , optimizerSettings.Background.Optimize
+                        , optimizerSettings.Cover.Optimize
+                        , optimizerSettings.Icon.Optimize);
                 }
-                , new GlobalProgressOptions("Optimizing game images...", false) { IsIndeterminate = games.Count == 1 });
+
+                api.Dialogs.ShowMessage($"Queued up {games.Count} games to optimize. Optimizing in the background.", "Queued up optimization");
+            }
+            else
+            {
+                api.Dialogs.ActivateGlobalProgress(
+                    globalProgress =>
+                    {
+                        globalProgress.ProgressMaxValue = games.Count;
+
+                        foreach (var game in games)
+                        {
+                            OptimizeGame(
+                                game.Id
+                                , optimizerSettings.Background.Optimize
+                                , optimizerSettings.Cover.Optimize
+                                , optimizerSettings.Icon.Optimize);
+
+                            globalProgress.CurrentProgressValue += 1;
+                        }
+                    }
+                    , new GlobalProgressOptions("Optimizing game images...", false) { IsIndeterminate = games.Count == 1 });
+            }
         }
 
         private void OptimizeGame(ItemUpdateEvent<Game> change, MetadataImageOptimizerSettings optimizerSettings)
@@ -121,26 +184,43 @@ namespace MetadataImageOptimizer
             var coverChanged = optimizerSettings.AlwaysOptimizeOnSave || change.OldData.CoverImage != change.NewData.CoverImage;
             var iconChanged = optimizerSettings.AlwaysOptimizeOnSave || change.OldData.Icon != change.NewData.Icon;
 
-            OptimizeGame(game, optimizerSettings, backgroundChanged, coverChanged, iconChanged);
+            if (backgroundChanged || coverChanged || iconChanged)
+            {
+                if (optimizerSettings.RunInBackground)
+                {
+                    // todo
+                    QueueOptimizeGame(game.Id, backgroundChanged, coverChanged, iconChanged);
+                }
+                else 
+                { 
+                    OptimizeGame(game.Id, backgroundChanged, coverChanged, iconChanged);
+                }
+            }
         }
 
-        private void OptimizeGame(Game game, MetadataImageOptimizerSettings optimizerSettings, bool optimizeBackground, bool optimizeCover, bool optimizeIcon)
+        private void OptimizeGame(Guid gameId, bool optimizeBackground, bool optimizeCover, bool optimizeIcon)
         {
             var modified = false;
+            var optimizerSettings = settings.Settings;
+
+            // Ensure we have the latest copy of {game}
+            var game = this.api.Database.Games.Get(gameId);
+
+            if (game == null)
+            {
+                return;
+            }
+
+            string newBackgroundPath = null;
+            string newCoverPath = null;
+            string newIconPath = null;
 
             if (optimizeBackground)
             {
                 try
                 {
                     var backgroundPath = api.Database.GetFullFilePath(game.BackgroundImage);
-                    var newBackgroundPath = ImageOptimizer.Optimize(backgroundPath, optimizerSettings.Background, optimizerSettings.Quality);
-                    if (!string.Equals(newBackgroundPath, backgroundPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        api.Database.RemoveFile(game.BackgroundImage);
-                        game.BackgroundImage = api.Database.AddFile(newBackgroundPath, game.Id);
-                        File.Delete(newBackgroundPath);
-                        modified = true;
-                    }
+                    newBackgroundPath = ImageOptimizer.Optimize(backgroundPath, optimizerSettings.Background, optimizerSettings.Quality);
                 }
                 catch (Exception ex)
                 {
@@ -153,14 +233,7 @@ namespace MetadataImageOptimizer
                 try
                 {
                     var coverPath = api.Database.GetFullFilePath(game.CoverImage);
-                    var newCoverPath = ImageOptimizer.Optimize(coverPath, optimizerSettings.Cover, optimizerSettings.Quality);
-                    if (!string.Equals(newCoverPath, coverPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        api.Database.RemoveFile(game.CoverImage);
-                        game.CoverImage = api.Database.AddFile(newCoverPath, game.Id);
-                        File.Delete(newCoverPath);
-                        modified = true;
-                    }
+                    newCoverPath = ImageOptimizer.Optimize(coverPath, optimizerSettings.Cover, optimizerSettings.Quality);
                 }
                 catch (Exception ex)
                 {
@@ -173,14 +246,7 @@ namespace MetadataImageOptimizer
                 try
                 {
                     var iconPath = api.Database.GetFullFilePath(game.Icon);
-                    var newIconPath = ImageOptimizer.Optimize(iconPath, optimizerSettings.Icon, optimizerSettings.Quality);
-                    if (!string.Equals(newIconPath, iconPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        api.Database.RemoveFile(game.Icon);
-                        game.Icon = api.Database.AddFile(newIconPath, game.Id);
-                        File.Delete(newIconPath);
-                        modified = true;
-                    }
+                    newIconPath = ImageOptimizer.Optimize(iconPath, optimizerSettings.Icon, optimizerSettings.Quality);
                 }
                 catch (Exception ex)
                 {
@@ -188,10 +254,145 @@ namespace MetadataImageOptimizer
                 }
             }
 
+            // Ensure we have the latest copy of {game} again in case it changed during the optimization
+            game = this.api.Database.Games.Get(gameId) ?? game;
+
+            if (newBackgroundPath != null && !string.Equals(newBackgroundPath, api.Database.GetFullFilePath(game.BackgroundImage), StringComparison.OrdinalIgnoreCase))
+            {
+                api.Database.RemoveFile(game.BackgroundImage);
+                game.BackgroundImage = api.Database.AddFile(newBackgroundPath, game.Id);
+                File.Delete(newBackgroundPath);
+                modified = true;
+            }
+
+            if (newCoverPath != null && !string.Equals(newCoverPath, api.Database.GetFullFilePath(game.CoverImage), StringComparison.OrdinalIgnoreCase))
+            {
+                api.Database.RemoveFile(game.CoverImage);
+                game.CoverImage = api.Database.AddFile(newCoverPath, game.Id);
+                File.Delete(newCoverPath);
+                modified = true;
+            }
+
+            if (newIconPath != null && !string.Equals(newIconPath, api.Database.GetFullFilePath(game.Icon), StringComparison.OrdinalIgnoreCase))
+            {
+                api.Database.RemoveFile(game.Icon);
+                game.Icon = api.Database.AddFile(newIconPath, game.Id);
+                File.Delete(newIconPath);
+                modified = true;
+            }
+
             if (modified)
             {
                 api.Database.Games.Update(game);
             }
         }
+
+        #region Background processing
+        private readonly System.Collections.Concurrent.ConcurrentQueue<Tuple<Guid, bool, bool, bool>> _backgroundOptimizeQueue =
+            new System.Collections.Concurrent.ConcurrentQueue<Tuple<Guid, bool, bool, bool>>();
+        private System.Threading.Thread _backgroundOptimizeThread = null;
+        private string _backgroundOptimizeQueueFilePath => Path.Combine(this.GetPluginUserDataPath(), "optimize-queue");
+
+        private void QueueOptimizeGame(Guid gameId, bool optimizeBackground, bool optimizeCover, bool optimizeIcon)
+        {
+            var queueItem = Tuple.Create(gameId, optimizeBackground, optimizeCover, optimizeIcon);
+
+            File.AppendAllLines(_backgroundOptimizeQueueFilePath, new[] { $"{queueItem.Item1},{queueItem.Item2},{queueItem.Item3},{queueItem.Item4}" });
+            _backgroundOptimizeQueue.Enqueue(queueItem);
+
+            EnsureBackgroundThreadRunning();
+        }
+
+        private void EnsureBackgroundThreadRunning(bool force = false)
+        {
+            if (_backgroundOptimizeThread != null && _backgroundOptimizeThread.IsAlive)
+            {
+                if (force)
+                {
+                    try
+                    {
+                        _backgroundOptimizeThread.Abort();
+                    }
+                    catch (Exception) { }
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            _backgroundOptimizeThread = new System.Threading.Thread(BackgroundOptimizeThread_Run) 
+            { IsBackground = true, Name = nameof(MetadataImageOptimizer) };
+
+            _backgroundOptimizeThread.Start();
+        }
+
+        private void BackgroundOptimizeThread_Run()
+        {
+            uint handled = 0u;
+
+            while (!Environment.HasShutdownStarted && _backgroundOptimizeQueue.TryDequeue(out var item))
+            {
+                OptimizeGame(item.Item1, item.Item2, item.Item3, item.Item4);
+
+                if (++handled % 100u == 0u)
+                {
+                    // Every {X} items we update the queue file to remove old items
+                    // We don't do it EVERY file because then we'd be potentially hammering the disk
+                    SaveBackgroundOptimizeQueueToFile();
+                }
+            }
+
+            SaveBackgroundOptimizeQueueToFile();
+        }
+
+        private void ClearBackgroundOptimizeQueue()
+        {
+            lock (_backgroundOptimizeQueue)
+            {
+                while (_backgroundOptimizeQueue.Count > 0)
+                {
+                    _backgroundOptimizeQueue.TryDequeue(out _);
+                }
+            }
+
+            SaveBackgroundOptimizeQueueToFile();
+        }
+
+        private void LoadBackgroundOptimizeQueueFromFile()
+        {
+            var lines = File.ReadAllLines(_backgroundOptimizeQueueFilePath);
+
+            foreach (var line in lines)
+            {
+                var parts = line.Split(',');
+
+                if (parts.Length == 4 &&
+                    Guid.TryParse(parts[0], out var gameId) &&
+                    bool.TryParse(parts[1], out var optimizeBackground) &&
+                    bool.TryParse(parts[2], out var optimizeCover) &&
+                    bool.TryParse(parts[3], out var optimizeIcon))
+                {
+                    _backgroundOptimizeQueue.Enqueue(Tuple.Create(gameId, optimizeBackground, optimizeCover, optimizeIcon));
+                }
+                else
+                {
+                    logger.Error($"Failed to parse optimize queue line: {line}");
+                }
+            }
+
+            EnsureBackgroundThreadRunning();
+        }
+
+        private void SaveBackgroundOptimizeQueueToFile()
+        {
+            lock (_backgroundOptimizeQueue)
+            {
+                File.WriteAllLines(
+                    _backgroundOptimizeQueueFilePath,
+                    _backgroundOptimizeQueue.Select(queueItem => $"{queueItem.Item1},{queueItem.Item2},{queueItem.Item3},{queueItem.Item4}"));
+            }
+        }
+        #endregion
     }
 }

--- a/src/MetadataImageOptimizer/MetadataImageOptimizer.cs
+++ b/src/MetadataImageOptimizer/MetadataImageOptimizer.cs
@@ -188,7 +188,6 @@ namespace MetadataImageOptimizer
             {
                 if (optimizerSettings.RunInBackground)
                 {
-                    // todo
                     QueueOptimizeGame(game.Id, backgroundChanged, coverChanged, iconChanged);
                 }
                 else 

--- a/src/MetadataImageOptimizer/Settings/MetadataImageOptimizerSettings.cs
+++ b/src/MetadataImageOptimizer/Settings/MetadataImageOptimizerSettings.cs
@@ -8,6 +8,7 @@ namespace MetadataImageOptimizer.Settings
     public class MetadataImageOptimizerSettings : ObservableObject
     {
         private bool alwaysOptimizeOnSave;
+        private bool runInBackground;
         private ImageTypeSettings background;
         private ImageTypeSettings cover;
         private ImageTypeSettings icon;
@@ -27,6 +28,7 @@ namespace MetadataImageOptimizer.Settings
         };
 
         public bool AlwaysOptimizeOnSave { get => alwaysOptimizeOnSave; set => SetValue(ref alwaysOptimizeOnSave, value); }
+        public bool RunInBackground { get => runInBackground; set => SetValue(ref runInBackground, value); }
         public ImageTypeSettings Background { get => background; set => SetValue(ref background, value); }
         public ImageTypeSettings Cover { get => cover; set => SetValue(ref cover, value); }
         public ImageTypeSettings Icon { get => icon; set => SetValue(ref icon, value); }

--- a/src/MetadataImageOptimizer/Views/GeneralSettingsView.xaml
+++ b/src/MetadataImageOptimizer/Views/GeneralSettingsView.xaml
@@ -21,16 +21,28 @@
       </Style.Setters>
     </Style>
   </UserControl.Resources>
-  <StackPanel Margin="15">
-    <StackPanel Orientation="Horizontal">
-      <CheckBox Content="Always optimize images when editing a game" IsChecked="{Binding Settings.AlwaysOptimizeOnSave}" />
+    <StackPanel Margin="15">
+        <StackPanel Orientation="Horizontal">
+            <CheckBox Content="Always optimize images when editing a game" IsChecked="{Binding Settings.AlwaysOptimizeOnSave}" />
+            <TextBlock Margin="10,0,0,0"
+        FontFamily="{DynamicResource FontIcoFont}"
+        Text="&#xefca;">
+                <TextBlock.ToolTip>
+                    <TextBlock>
+            If enabled: When a game entry is saved, all image types where 'Optimize' is checked will be optimized.<LineBreak />
+            If disabled: When a game entry is saved, only images that were modified and where 'Optimize' is checked will be optimized.</TextBlock>
+                </TextBlock.ToolTip>
+      </TextBlock>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+      <CheckBox Content="Run in background" IsChecked="{Binding Settings.RunInBackground}" />
       <TextBlock Margin="10,0,0,0"
         FontFamily="{DynamicResource FontIcoFont}"
         Text="&#xefca;">
         <TextBlock.ToolTip>
           <TextBlock>
-            If enabled: When a game entry is saved, all image types where 'Optimize' is checked will be optimized.<LineBreak />
-            If disabled: When a game entry is saved, only images that were modified and where 'Optimize' is checked will be optimized.</TextBlock>
+            If enabled: Images will be optimized in the background in a queue.
+          </TextBlock>
         </TextBlock.ToolTip>
       </TextBlock>
     </StackPanel>


### PR DESCRIPTION
I've added a new setting in the Settings window for running image optimizations in the background. If disabled, there's basically no changes, other than some failsafe code in the OptimizeGame function which makes sure the Game being worked on is the same as the one currently in the item database.

If the background option is enabled, then a ConcurrentQueue is used to handle the optimization requests in a FIFO order. It has a backing file which it uses to make sure that it continues optimizing even if Playnite gets closed and reopened. 

There's also a new Main Menu option added if optimization is currently happening, giving users the ability to cancel it.