### PR TITLE
fix PackageUrl typo

### DIFF
--- a/manifests/Generic_MetadataImageOptimizer.yaml
+++ b/manifests/Generic_MetadataImageOptimizer.yaml
@@ -46,6 +46,6 @@ Packages:
   - Version: 1.6
     RequiredApiVersion: 6.2.0
     ReleaseDate: 2024-11-26
-    PackageUrl: https://github.com/UrbanCMC/PlayniteExtensions/releases/download/metadataimageoptimizer1.5/MetadataImageOptimizer_1_6.pext
+    PackageUrl: https://github.com/UrbanCMC/PlayniteExtensions/releases/download/metadataimageoptimizer1.6/MetadataImageOptimizer_1_6.pext
     Changelog:
     - Fix error that breaks images when editing a game that is being processed in the background


### PR DESCRIPTION
PackageUrl for 1.6 was still set to /metadataimageoptimizer1.5/ folder